### PR TITLE
Add solveintro command

### DIFF
--- a/plopfile.ts
+++ b/plopfile.ts
@@ -25,6 +25,7 @@ export default (plop: NodePlopAPI) => {
         choices: [
           // TODO add more categories as needed
           { name: "Dev", value: "dev" },
+	  { name: "General", value: "general" },
         ],
       },
     ],

--- a/src/events/message/commands/general/solveintro.ts
+++ b/src/events/message/commands/general/solveintro.ts
@@ -1,0 +1,57 @@
+import { User, GuildMember } from "discord.js";
+import { Message, CommandArg } from "../types";
+
+// solveintro
+export default async (message: Message, args: CommandArg[]) => {
+  // Authorization
+  let author = message.guild?.members.cache.get(message.author.id);
+  if (!(author instanceof GuildMember))
+    return;
+  let isPrivileged = author.roles
+    .cache
+    .some(role => role.name === 'admin' || role.name === 'mods');
+  if (!isPrivileged)
+    return;
+
+  // Input validation
+  if (args.length !== 1)
+    return;
+  let mention = args[0];
+  if (typeof mention !== 'object')
+    return;
+  if (mention.type !== 'user')
+    return;
+  if (typeof mention.id !== 'string')
+    return;
+  let user = message.client.users.cache.get(mention.id);
+  if (!(user instanceof User))
+    return;
+
+  // Action
+  try {
+    const dm = await user.createDM();
+    await dm.send(SOLVE_INTRO);
+    await message.channel.send(`<@${mention.id}> I sent you a DM, please check your inbox ;-)`);
+  } catch (err) {
+    console.warn(`failed to DM ${user.tag}: ${err.message || "unknown error"}`);
+    await message.channel.send(`<@${mention.id}> ${SOLVE_INTRO}`);
+  }
+};
+
+const SOLVE_INTRO = `Welcome! For an optimal experience, please include the following information **in #help-solve** (not to me!):
+
+1. A link to the Kata you are attempting, e.g. <https://www.codewars.com/kata/50654ddff44f800200000004>
+2. The language you are attempting the Kata in, e.g. JavaScript
+3. What you have tried before asking for help. We'd love to put in the effort to help you, but only if you first help yourself.
+4. Your current solution in properly formatted code blocks. For example:
+
+\\\`\\\`\\\`javascript
+console.log("Hello World!");
+\\\`\\\`\\\`
+
+gives
+
+\`\`\`javascript
+console.log("Hello World!");
+\`\`\`
+5. The input, output from your solution and expected output`;

--- a/src/events/message/commands/index.ts
+++ b/src/events/message/commands/index.ts
@@ -3,9 +3,11 @@ export { parse as parseArguments } from "./args";
 
 import ping from "./dev/ping";
 import dump from "./dev/dump";
+import solveintro from "./general/solveintro";
 
 const commands: { [k: string]: Command } = {
   ping,
   dump,
+  solveintro,
 };
 export default commands;


### PR DESCRIPTION
`?solveintro @mention` sends a direct message (DM) to the mentioned user with detailed guidelines on how to effectively ask for help on solving a Kata in the #help-solve channel, followed by a brief message in the given channel prompting the mentioned user to check his/her DMs. In the case where the mentioned user is unable to receive DMs, the fallback action is to post the contents of the DM on the given channel mentioning the user.

This command is only available to admins and mods, so the risk of the command being abused to spam someone with DMs is low.