### PR TITLE
Add `?introduce @user #help-solve`

### DIFF
--- a/plopfile.ts
+++ b/plopfile.ts
@@ -25,6 +25,7 @@ export default (plop: NodePlopAPI) => {
         choices: [
           // TODO add more categories as needed
           { name: "Dev", value: "dev" },
+          { name: "Help", value: "help" },
         ],
       },
     ],

--- a/src/events/message/commands/help/introduce.ts
+++ b/src/events/message/commands/help/introduce.ts
@@ -1,7 +1,7 @@
-import { Message, CommandArg } from "../types";
-import { Role, TextChannel } from "discord.js";
 import { readFileSync } from "fs";
 import * as path from "path";
+import { Role, TextChannel } from "discord.js";
+import { Message, CommandArg } from "../types";
 
 const isModerator = (role: Role) => role.name === "admin" || role.name === "mods";
 const channels = ["help-solve"];

--- a/src/events/message/commands/help/introduce.ts
+++ b/src/events/message/commands/help/introduce.ts
@@ -1,0 +1,84 @@
+import { Message, CommandArg } from "../types";
+import { Role, TextChannel } from "discord.js";
+
+const isModerator = (role: Role) => role.name === "admin" || role.name === "mods";
+
+// introduce
+export default async (message: Message, args: CommandArg[]) => {
+  // Authorization
+  const author = message.guild?.members.cache.get(message.author.id);
+  if (!author) return;
+  const isPrivileged = author.roles.cache.some(isModerator);
+  if (!isPrivileged) return;
+
+  // Input validation
+  if (args.length < 1 || args.length > 2) return;
+  const mention = args[0];
+  if (typeof mention !== "object") return;
+  if (mention.type !== "user") return;
+  const user = message.client.users.cache.get(mention.id);
+  if (!user) return;
+  let channelMention, channel;
+  if (args.length > 1) {
+    channelMention = args[1];
+    if (typeof channelMention !== "object") return;
+    if (channelMention.type !== "channel") return;
+    channel = message.client.channels.cache.get(channelMention.id);
+    if (!(channel instanceof TextChannel)) return;
+  }
+
+  // Action
+  const reply = !channel
+    ? INTRO
+    : channel.name === "help-solve"
+    ? HELP_SOLVE
+    : channel.name === "off-topic"
+    ? OFF_TOPIC
+    : INTRO;
+  try {
+    const dm = await user.createDM();
+    await dm.send(reply);
+  } catch (err) {
+    console.warn(`failed to DM ${user.tag}: ${err.message || "unknown error"}`);
+    await message.channel.send(`<@${mention.id}> ${reply}`);
+  }
+};
+
+const INTRO = `Welcome to the Codewars Discord server!
+
+Codewars is where developers achieve mastery through challenge and improve their skills by training with others on real code challenges. Go check it out if you haven't done so already: https://www.codewars.com/
+
+Some channels to help you get started:
+
+- #beginners is for newcomers to programming
+- #codewars is for general Codewars discussion. This is also a great place to introduce yourself as a Codewars user
+- #off-topic is for pretty much anything, whether related to Codewars or not. Kitty pictures are also welcome :-)
+- If you need help on solving a Codewars Kata, go to #help-solve
+- There are also a number of language subs for discussing stuff related to a particular programming language, related to Codewars or otherwise. If you do JavaScript, check out #javascript
+
+Finally, if you would like to contribute to making me better, feel free to leave comments and feedback at #discord-bot`;
+
+const HELP_SOLVE = `Welcome to #help-solve! For an optimal experience, please include the following information **in #help-solve** (not to me!):
+
+1. A link to the Kata you are attempting, e.g. <https://www.codewars.com/kata/50654ddff44f800200000004>
+2. The language you are attempting the Kata in, e.g. JavaScript
+3. What you have tried before asking for help. We'd love to put in the effort to help you, but only if you first help yourself.
+4. Your current solution in properly formatted code blocks. For example:
+
+\\\`\\\`\\\`javascript
+console.log("Hello World!");
+\\\`\\\`\\\`
+
+gives
+
+\`\`\`javascript
+console.log("Hello World!");
+\`\`\`
+5. The input, output from your solution and expected output`;
+
+const OFF_TOPIC = `Welcome to #off-topic! This channel is for off-topic discussion, so pretty much anything that is appropriate for all ages can be discussed here, whether related to programming or not. However, we ask you to respect a few rules:
+
+- Please adhere to the Codewars Terms of Service (ToS) at all times: <https://www.codewars.com/about/terms-of-service>
+- Please adhere to the Discord Terms of Service (ToS) at all times: <https://discord.com/terms>
+- This is _not_ a place for you to advertise your own products and/or services. You may receive a warning in mild cases, and a kick from the server in severe cases. Repeat offenders will be **permanently banned**
+- Nor is this a place to receive free help for completing your programming homework, project, assignment, etc. Similar measures apply as for advertising`;

--- a/src/events/message/commands/help/introduce.ts
+++ b/src/events/message/commands/help/introduce.ts
@@ -32,8 +32,8 @@ export default async (message: Message, args: CommandArg[]) => {
     ? INTRO
     : channel.name === "help-solve"
     ? HELP_SOLVE
-    : channel.name === "off-topic"
-    ? OFF_TOPIC
+    : channel.name === "anything"
+    ? ANYTHING
     : INTRO;
   try {
     const dm = await user.createDM();
@@ -52,7 +52,7 @@ Some channels to help you get started:
 
 - #beginners is for newcomers to programming
 - #codewars is for general Codewars discussion. This is also a great place to introduce yourself as a Codewars user
-- #off-topic is for pretty much anything, whether related to Codewars or not. Kitty pictures are also welcome :-)
+- #anything is for pretty much anything, whether related to Codewars or not. Kitty pictures are also welcome :-)
 - If you need help on solving a Codewars Kata, go to #help-solve
 - There are also a number of language subs for discussing stuff related to a particular programming language, related to Codewars or otherwise. If you do JavaScript, check out #javascript
 
@@ -76,7 +76,7 @@ console.log("Hello World!");
 \`\`\`
 5. The input, output from your solution and expected output`;
 
-const OFF_TOPIC = `Welcome to #off-topic! This channel is for off-topic discussion, so pretty much anything that is appropriate for all ages can be discussed here, whether related to programming or not. However, we ask you to respect a few rules:
+const ANYTHING = `Welcome to #anything! You can discuss pretty much anything that is appropriate for all ages on this channel, whether related to programming or not. However, we ask you to respect a few rules:
 
 - Please adhere to the Codewars Terms of Service (ToS) at all times: <https://www.codewars.com/about/terms-of-service>
 - Please adhere to the Discord Terms of Service (ToS) at all times: <https://discord.com/terms>

--- a/src/events/message/commands/help/introduce.ts
+++ b/src/events/message/commands/help/introduce.ts
@@ -22,7 +22,6 @@ export default async (message: Message, args: CommandArg[]) => {
   const user = message.client.users.cache.get(mention.id);
   if (!user) return;
   const channelMention = args[1];
-  if (typeof channelMention !== "object") return;
   if (channelMention.type !== "channel") return;
   const channel = message.client.channels.cache.get(channelMention.id);
   if (!(channel instanceof TextChannel)) return;

--- a/src/events/message/commands/help/introduce.ts
+++ b/src/events/message/commands/help/introduce.ts
@@ -17,7 +17,6 @@ export default async (message: Message, args: CommandArg[]) => {
   // Input validation
   if (args.length !== 2) return;
   const mention = args[0];
-  if (typeof mention !== "object") return;
   if (mention.type !== "user") return;
   const user = message.client.users.cache.get(mention.id);
   if (!user) return;

--- a/src/events/message/commands/help/introduce.ts
+++ b/src/events/message/commands/help/introduce.ts
@@ -1,7 +1,10 @@
 import { Message, CommandArg } from "../types";
 import { Role, TextChannel } from "discord.js";
+import { promises } from "fs";
+import * as path from "path";
 
 const isModerator = (role: Role) => role.name === "admin" || role.name === "mods";
+const channels = ["help-solve"];
 
 // introduce
 export default async (message: Message, args: CommandArg[]) => {
@@ -12,29 +15,28 @@ export default async (message: Message, args: CommandArg[]) => {
   if (!isPrivileged) return;
 
   // Input validation
-  if (args.length < 1 || args.length > 2) return;
+  if (args.length !== 2) return;
   const mention = args[0];
   if (typeof mention !== "object") return;
   if (mention.type !== "user") return;
   const user = message.client.users.cache.get(mention.id);
   if (!user) return;
-  let channelMention, channel;
-  if (args.length > 1) {
-    channelMention = args[1];
-    if (typeof channelMention !== "object") return;
-    if (channelMention.type !== "channel") return;
-    channel = message.client.channels.cache.get(channelMention.id);
-    if (!(channel instanceof TextChannel)) return;
-  }
+  const channelMention = args[1];
+  if (typeof channelMention !== "object") return;
+  if (channelMention.type !== "channel") return;
+  const channel = message.client.channels.cache.get(channelMention.id);
+  if (!(channel instanceof TextChannel)) return;
+  if (!channels.includes(channel.name)) return;
 
   // Action
-  const reply = !channel
-    ? INTRO
-    : channel.name === "help-solve"
-    ? HELP_SOLVE
-    : channel.name === "anything"
-    ? ANYTHING
-    : INTRO;
+  const dmPath = path.join(path.join(process.cwd(), "text"), `${channel.name}.txt`);
+  let reply;
+  try {
+    reply = (await promises.readFile(dmPath)).toString();
+  } catch (err) {
+    console.warn(`failed to open file ${dmPath}: ${err.message || "unknown error"}`);
+    return;
+  }
   try {
     const dm = await user.createDM();
     await dm.send(reply);
@@ -43,42 +45,3 @@ export default async (message: Message, args: CommandArg[]) => {
     await message.channel.send(`<@${mention.id}> ${reply}`);
   }
 };
-
-const INTRO = `Welcome to the Codewars Discord server!
-
-Codewars is where developers achieve mastery through challenge and improve their skills by training with others on real code challenges. Go check it out if you haven't done so already: https://www.codewars.com/
-
-Some channels to help you get started:
-
-- #beginners is for newcomers to programming
-- #codewars is for general Codewars discussion. This is also a great place to introduce yourself as a Codewars user
-- #anything is for pretty much anything, whether related to Codewars or not. Kitty pictures are also welcome :-)
-- If you need help on solving a Codewars Kata, go to #help-solve
-- There are also a number of language subs for discussing stuff related to a particular programming language, related to Codewars or otherwise. If you do JavaScript, check out #javascript
-
-Finally, if you would like to contribute to making me better, feel free to leave comments and feedback at #discord-bot`;
-
-const HELP_SOLVE = `Welcome to #help-solve! For an optimal experience, please include the following information **in #help-solve** (not to me!):
-
-1. A link to the Kata you are attempting, e.g. <https://www.codewars.com/kata/50654ddff44f800200000004>
-2. The language you are attempting the Kata in, e.g. JavaScript
-3. What you have tried before asking for help. We'd love to put in the effort to help you, but only if you first help yourself.
-4. Your current solution in properly formatted code blocks. For example:
-
-\\\`\\\`\\\`javascript
-console.log("Hello World!");
-\\\`\\\`\\\`
-
-gives
-
-\`\`\`javascript
-console.log("Hello World!");
-\`\`\`
-5. The input, output from your solution and expected output`;
-
-const ANYTHING = `Welcome to #anything! You can discuss pretty much anything that is appropriate for all ages on this channel, whether related to programming or not. However, we ask you to respect a few rules:
-
-- Please adhere to the Codewars Terms of Service (ToS) at all times: <https://www.codewars.com/about/terms-of-service>
-- Please adhere to the Discord Terms of Service (ToS) at all times: <https://discord.com/terms>
-- This is _not_ a place for you to advertise your own products and/or services. You may receive a warning in mild cases, and a kick from the server in severe cases. Repeat offenders will be **permanently banned**
-- Nor is this a place to receive free help for completing your programming homework, project, assignment, etc. Similar measures apply as for advertising`;

--- a/src/events/message/commands/index.ts
+++ b/src/events/message/commands/index.ts
@@ -3,9 +3,11 @@ export { parse as parseArguments } from "./args";
 
 import ping from "./dev/ping";
 import dump from "./dev/dump";
+import introduce from "./help/introduce";
 
 const commands: { [k: string]: Command } = {
   ping,
   dump,
+  introduce,
 };
 export default commands;

--- a/text/help-solve.md
+++ b/text/help-solve.md
@@ -14,4 +14,5 @@ gives
 ```javascript
 console.log("Hello World!");
 ```
+
 5. The input, output from your solution and expected output

--- a/text/help-solve.md
+++ b/text/help-solve.md
@@ -5,9 +5,9 @@ Welcome to #help-solve! For an optimal experience, please include the following 
 3. What you have tried before asking for help. We'd love to put in the effort to help you, but only if you first help yourself.
 4. Your current solution in properly formatted code blocks. For example:
 
-\`\`\`javascript
-console.log("Hello World!");
-\`\`\`
+\`\`\`javascript  
+console.log("Hello World!");  
+\`\`\`  
 
 gives
 

--- a/text/help-solve.txt
+++ b/text/help-solve.txt
@@ -1,0 +1,17 @@
+Welcome to #help-solve! For an optimal experience, please include the following information **in #help-solve** (not to me!):
+
+1. A link to the Kata you are attempting, e.g. <https://www.codewars.com/kata/50654ddff44f800200000004>
+2. The language you are attempting the Kata in, e.g. JavaScript
+3. What you have tried before asking for help. We'd love to put in the effort to help you, but only if you first help yourself.
+4. Your current solution in properly formatted code blocks. For example:
+
+\`\`\`javascript
+console.log("Hello World!");
+\`\`\`
+
+gives
+
+```javascript
+console.log("Hello World!");
+```
+5. The input, output from your solution and expected output

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -5,10 +5,6 @@
     "outDir": "lib",
     "removeComments": true
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "src/**/*.test.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
This command is only available to admins and mods.

- `?introduce @mention #help-solve`: DM's the mentioned user with guidelines on asking for help on solving Codewars Kata. Falls back to mentioning the user in the channel if DM is not available.

I have implemented most of the suggestions from the previous pull request, except that the messages are currently hardcoded in the source code instead of in separate text files. It was mentioned that the text files containing the messages should be in a separate directory, but which directory should we put it in? Once we've agreed on that, I can move the message contents out into a separate directory and fix any remaining issues.