### PR TITLE
Refine contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,15 @@ After forking this repo and cloning your fork to your local development environm
 
 1. Change directory to the root of this repo: `$ cd /path/to/your/discord-bot`
 1. Install dependencies: `$ npm install`
-1. Compile the TypeScript source files: `$ npm run build`
-1. Run your bot with [your token](https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token): `$ BOT_TOKEN=... npm start`
+1. Compile the TypeScript source files and configure it to automatically re-compile on modification: `$ npm run build:watch`
+1. In a new terminal session, run the bot with [your token](https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token): `$ BOT_TOKEN=... npm start`
 
-After confirming that the bot works as expected, make changes to the local copy of your fork as appropriate and test your changes with the following steps:
+After confirming that the bot works as expected, make changes to the local copy of your fork as appropriate and test your changes by restarting the bot.
 
-1. Change directory to the root of this repo: `$ cd /path/to/your/discord-bot`
-1. Fix the formatting of your code with Prettier for consistency: `$ npx prettier --write .`
-1. Rebuild the project: `$ npm run build`
-1. Re-run your bot with your token: `$ BOT_TOKEN=... npm start`
+Before commiting your changes and opening a pull request, make sure your code is properly formatted. Normally there should be a git hook that runs [Prettier](https://www.npmjs.com/package/prettier) on your code automatically on every commit, but if that is not the case, you have two options:
 
-To avoid the manual re-formatting step with Prettier, you may wish to configure your text editor or IDE to run the command on every save.
+1. Change directory to the root of this repo and run `$ npm prettier --write .` once before commit, or
+1. Configure your IDE / text editor to automatically invoke Prettier on every save
 
 ### Adding a new command
 

--- a/README.md
+++ b/README.md
@@ -20,52 +20,38 @@ The following environment variables are used:
 
 ## Developement Setup
 
+Before working on this repo, you should already have [set up a bot account](https://discordjs.guide/preparations/setting-up-a-bot-application.html#creating-your-bot) and [added it to your development server](https://discordjs.guide/preparations/adding-your-bot-to-servers.html). In order to mimic the Codewars Discord server in your development server, you may also wish to add appropriate roles such as @admin and @mods, as well as common channels such as #help-solve.
+
 > NOTE: Please discuss with us first before adding new features to avoid wasting your time.
 
 > TODO Expand
 
-### Install dependencies and build
+After forking this repo and cloning your fork to your local development environment:
 
-```bash
-npm install
-```
+1. Change directory to the root of this repo: `$ cd /path/to/your/discord-bot`
+1. Install dependencies: `$ npm install`
+1. Compile the TypeScript source files: `$ npm run build`
+1. Run your bot with [your token](https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token): `$ BOT_TOKEN=... npm start`
 
-### Start bot with your token
+After confirming that the bot works as expected, make changes to the local copy of your fork as appropriate and test your changes with the following steps:
 
-```bash
-BOT_TOKEN=.... npm start
-```
+1. Change directory to the root of this repo: `$ cd /path/to/your/discord-bot`
+1. Fix the formatting of your code with Prettier for consistency: `$ npx prettier --write .`
+1. Rebuild the project: `$ npm run build`
+1. Re-run your bot with your token: `$ BOT_TOKEN=... npm start`
 
-### Making changes
-
-Let TypeScript compile on change:
-
-```bash
-npm run build:watch
-```
-
-and restart the bot.
-
-Run tests automatically on save with:
-
-```bash
-npm run test:watch
-```
-
-Run all tests with:
-
-```bash
-npm run test
-```
+To avoid the manual re-formatting step with Prettier, you may wish to configure your text editor or IDE to run the command on every save.
 
 ### Adding a new command
 
-Run `npx plop command` to generate boilerplate.
+Run `npx plop command` to generate boilerplate. You will be asked to enter the name of the command (lowercase English letters only) which should be a verb and select an associated category.
+
+If your command belongs to a category that does not exist yet, stop the command generation by pressing `Ctrl-C`, then modify `plopfile.ts` as appropriate to add your category and re-run `npx plop command`.
 
 ### Adding a new message handler
 
 Run `npx plop message-handler` to generate boilerplate.
 
-## TODO
+## License
 
-- [ ] Write contribution guides
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ After forking this repo and cloning your fork to your local development environm
 
 After confirming that the bot works as expected, make changes to the local copy of your fork as appropriate and test your changes by restarting the bot.
 
-Before commiting your changes and opening a pull request, make sure your code is properly formatted. Normally there should be a git hook that runs [Prettier](https://www.npmjs.com/package/prettier) on your code automatically on every commit, but if that is not the case, you have two options:
+### Code Style
 
-1. Change directory to the root of this repo and run `$ npm prettier --write .` once before commit, or
-1. Configure your IDE / text editor to automatically invoke Prettier on every save
+[Prettier](https://prettier.io/) is used to ensure consistent style. We use the defaults except for `printWidth: 100` because `80` is often too narrow with types.
+
+Git `pre-commit` hook to format staged changes are installed automatically when you run `npm install`, so you don't need to do anything. However, it's recommended to [configure your editor](https://prettier.io/docs/en/editors.html) to format on save, and forget about formatting.
+
 
 ### Adding a new command
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Before working on this repo, you should already have [set up a bot account](http
 After forking this repo and cloning your fork to your local development environment:
 
 1. Change directory to the root of this repo: `$ cd /path/to/your/discord-bot`
-1. Install dependencies: `$ npm install`
-1. Compile the TypeScript source files and configure it to automatically re-compile on modification: `$ npm run build:watch`
+1. Install dependencies and compile TypeScript: `$ npm install`
+1. Start TypeScript compiler process to recompile on change: `$ npm run build:watch`
 1. In a new terminal session, run the bot with [your token](https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token): `$ BOT_TOKEN=... npm start`
 
 After confirming that the bot works as expected, make changes to the local copy of your fork as appropriate and test your changes by restarting the bot.


### PR DESCRIPTION
Currently the README is still a bit terse and could be made friendlier to newcomers who wish to contribute to the bot. This pull request aims to improve the contribution guide so anyone can easily contribute.

In particular, @hobovsky previously expressed an interest in contributing to our Discord bot but was not sure where to start; therefore, I would like to ask for his review and input on the modified contribution guides.