### PR TITLE
Add ?link command

### DIFF
--- a/src/events/message/commands/help/link.ts
+++ b/src/events/message/commands/help/link.ts
@@ -11,6 +11,7 @@ const LINKS: { [k: string]: string } = {
   ranking: "https://docs.codewars.com/curation/kata",
   troubleshooting: "https://docs.codewars.com/training/troubleshooting",
   github: "https://github.com/codewars/",
+  clans: "https://docs.codewars.com/community/following/#clans",
 };
 
 const USAGE: string = `Usage: \`?link {${Object.keys(LINKS).join("|")}}\``;

--- a/src/events/message/commands/help/link.ts
+++ b/src/events/message/commands/help/link.ts
@@ -25,5 +25,5 @@ export default async (message: Message, args: CommandArg[]) => {
   const [link] = result.data;
 
   // Respond with link
-  await message.channel.send(`<${LINKS[link]}>`);
+  await message.channel.send(`See <${LINKS[link]}>`);
 };

--- a/src/events/message/commands/help/link.ts
+++ b/src/events/message/commands/help/link.ts
@@ -10,7 +10,7 @@ const LINKS: { [k: string]: string } = {
   authoring: "https://docs.codewars.com/authoring",
   ranking: "https://docs.codewars.com/curation/kata",
   troubleshooting: "https://docs.codewars.com/training/troubleshooting",
-  github: "https://github.com/codewars/codewars.com/issues",
+  github: "https://github.com/codewars/",
 };
 
 const USAGE: string = `Usage: \`?link {${Object.keys(LINKS).join("|")}}\``;

--- a/src/events/message/commands/help/link.ts
+++ b/src/events/message/commands/help/link.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { CommandArg, Message, word } from "../types";
+
+// "?link <topic>" provides a simple shortcut to various useful URLs
+
+const LINKS: { [k: string]: string } = {
+  docs: "https://docs.codewars.com/",
+  honor: "https://docs.codewars.com/gamification/honor",
+  katas: "https://www.codewars.com/kata/latest/my-languages",
+  authoring: "https://docs.codewars.com/authoring",
+  ranking: "https://docs.codewars.com/curation/kata",
+  troubleshooting: "https://docs.codewars.com/training/troubleshooting",
+  github: "https://github.com/codewars/codewars.com/issues",
+};
+
+const USAGE: string = `Usage: \`?link {${Object.keys(LINKS).join("|")}}\``;
+
+export default async (message: Message, args: CommandArg[]) => {
+  // Input validation
+  const result = z.tuple([word((w) => LINKS.hasOwnProperty(w))]).safeParse(args);
+  if (!result.success) {
+    message.reply(USAGE);
+    return;
+  }
+  const [link] = result.data;
+
+  // Respond with link
+  await message.channel.send(`<${LINKS[link]}>`);
+};

--- a/src/events/message/commands/index.ts
+++ b/src/events/message/commands/index.ts
@@ -5,11 +5,13 @@ import ping from "./dev/ping";
 import dump from "./dev/dump";
 import introduce from "./help/introduce";
 import warn from "./moderation/warn";
+import link from "./help/link";
 
 const commands: { [k: string]: Command } = {
   ping,
   dump,
   introduce,
   warn,
+  link,
 };
 export default commands;


### PR DESCRIPTION
Provides a quick way to access useful links, usually when guiding a user to a particular page.

Example:
```
no0bUser99: Hey guys I want to create my first kata, how do I do this?
Kacarott:   You should read this:
Kacarott:   ?link authoring
Codewars:   https://docs.codewars.com/authoring
no0bUser99: Ok thanks!
```

Currently implemented `?link`s:
- [docs](https://docs.codewars.com/)
- [honor](https://docs.codewars.com/gamification/honor)
- [katas](https://www.codewars.com/kata/latest/my-languages)
- [authoring](https://docs.codewars.com/authoring)
- [ranking](https://docs.codewars.com/curation/kata)
- [troubleshooting](https://docs.codewars.com/training/troubleshooting)
- [github](https://github.com/codewars/codewars.com/issues)