### PR TITLE
Add ?link debug as alias for ?link troubleshooting

### DIFF
--- a/src/events/message/commands/help/link.ts
+++ b/src/events/message/commands/help/link.ts
@@ -10,6 +10,7 @@ const LINKS: { [k: string]: string } = {
   authoring: "https://docs.codewars.com/authoring",
   ranking: "https://docs.codewars.com/curation/kata",
   troubleshooting: "https://docs.codewars.com/training/troubleshooting",
+  debug: "https://docs.codewars.com/training/troubleshooting",
   github: "https://github.com/codewars/",
   clans: "https://docs.codewars.com/community/following/#clans",
 };


### PR DESCRIPTION
It's much shorter, and so it becomes less likely to have typos when using it.