### PR TITLE
Take PREFIX into account in command help messages

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -7,6 +7,10 @@ const isTrustedUser = (role: Role) => isModerator(role) || role.name === "power-
 
 const textPath = path.join(__dirname, "../text");
 
+const DEFAULT_PREFIX = "?";
+
+export const PREFIX = process.env.COMMAND_PREFIX || DEFAULT_PREFIX;
+
 export const fromModerator = (message: Message): boolean => {
   const author = message.guild?.members.cache.get(message.author.id);
   if (!author) return false;

--- a/src/events/message/commands/fun/rankup.ts
+++ b/src/events/message/commands/fun/rankup.ts
@@ -150,10 +150,7 @@ export default async function (message: Message, args: CommandArg[], opts: Optio
   };
 
   // If current channel is not #bot-playground, redirect them to that channel
-  if ((message.channel as TextChannel).name !== "bot-playground") {
-    message.reply(REDIRECT);
-    return;
-  }
+  if ((message.channel as TextChannel).name !== "bot-playground") return send(REDIRECT);
 
   let username: string;
   if (args.length == 0) {
@@ -170,10 +167,7 @@ export default async function (message: Message, args: CommandArg[], opts: Optio
   }
 
   // If help option set, simply reply with usage info
-  if (opts.help !== undefined) {
-    message.reply(USAGE);
-    return;
-  }
+  if (opts.help !== undefined) return send(USAGE);
 
   // Get mode
   const mode = isMode(opts.mode) ? opts.mode : DEFAULTMODE;

--- a/src/events/message/commands/fun/rankup.ts
+++ b/src/events/message/commands/fun/rankup.ts
@@ -2,8 +2,7 @@ import { TextChannel } from "discord.js";
 import { z, ZodError } from "zod";
 import { Message, CommandArg, word } from "../types";
 import { getUser, UserNotFoundError } from "../../../../codewars";
-
-const PREFIX = process.env.COMMAND_PREFIX || "?";
+import { PREFIX } from "../../../../common";
 
 const USAGE: string = `Usage: \`${PREFIX}rankup [<username> --target={username|rank} --language={languageID} --mode={least|each|spread} --limit={1-8[kyu]}]\``;
 const REDIRECT: string = "This command is only available in channel **#bot-playground**";

--- a/src/events/message/commands/fun/rankup.ts
+++ b/src/events/message/commands/fun/rankup.ts
@@ -3,12 +3,13 @@ import { z, ZodError } from "zod";
 import { Message, CommandArg, word } from "../types";
 import { getUser, UserNotFoundError } from "../../../../codewars";
 
-const USAGE: string =
-  "Usage: `?rankup [<username> --target={username|rank} --language={languageID} --mode={least|each|spread} --limit={1-8[kyu]}]`";
+const PREFIX = process.env.COMMAND_PREFIX || "?";
+
+const USAGE: string = `Usage: \`${PREFIX}rankup [<username> --target={username|rank} --language={languageID} --mode={least|each|spread} --limit={1-8[kyu]}]\``;
 const REDIRECT: string = "This command is only available in channel **#bot-playground**";
 
 /*
-`?rankup` calculates the number of katas of each rank required for a user to rank up.
+`${PREFIX}rankup` calculates the number of katas of each rank required for a user to rank up.
 This command is just for fun, however should increase competition between users,
 and (hopefully) increase motivation.
 
@@ -150,7 +151,10 @@ export default async function (message: Message, args: CommandArg[], opts: Optio
   };
 
   // If current channel is not #bot-playground, redirect them to that channel
-  if ((message.channel as TextChannel).name !== "bot-playground") return send(REDIRECT);
+  if ((message.channel as TextChannel).name !== "bot-playground") {
+    message.reply(REDIRECT);
+    return;
+  }
 
   let username: string;
   if (args.length == 0) {
@@ -167,7 +171,10 @@ export default async function (message: Message, args: CommandArg[], opts: Optio
   }
 
   // If help option set, simply reply with usage info
-  if (opts.help !== undefined) return send(USAGE);
+  if (opts.help !== undefined) {
+    message.reply(USAGE);
+    return;
+  }
 
   // Get mode
   const mode = isMode(opts.mode) ? opts.mode : DEFAULTMODE;

--- a/src/events/message/commands/help/introduce.ts
+++ b/src/events/message/commands/help/introduce.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
-
 import { fromTrustedUser, getTexts } from "../../../../common";
 import { Message, CommandArg, discordUser, discordTextChannel } from "../types";
 
+const PREFIX = process.env.COMMAND_PREFIX || "?";
+
 const channels = ["help-solve"];
-const USAGE = `Usage: \`?introduce @user #{${channels.join(",")}}\``;
+const USAGE = `Usage: \`${PREFIX}introduce @user #{${channels.join(",")}}\``;
 const channelTexts: Map<string, string> = getTexts("introduce", channels);
 
 // introduce

--- a/src/events/message/commands/help/introduce.ts
+++ b/src/events/message/commands/help/introduce.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 import { fromTrustedUser, getTexts } from "../../../../common";
 import { Message, CommandArg, discordUser, discordTextChannel } from "../types";
-
-const PREFIX = process.env.COMMAND_PREFIX || "?";
+import { PREFIX } from "../../../../common";
 
 const channels = ["help-solve"];
 const USAGE = `Usage: \`${PREFIX}introduce @user #{${channels.join(",")}}\``;

--- a/src/events/message/commands/help/link.ts
+++ b/src/events/message/commands/help/link.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { CommandArg, Message, word } from "../types";
-
-const PREFIX = process.env.COMMAND_PREFIX || "?";
+import { PREFIX } from "../../../../common";
 
 // `${PREFIX}link <topic>` provides a simple shortcut to various useful URLs
 

--- a/src/events/message/commands/help/link.ts
+++ b/src/events/message/commands/help/link.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 import { CommandArg, Message, word } from "../types";
 
-// "?link <topic>" provides a simple shortcut to various useful URLs
+const PREFIX = process.env.COMMAND_PREFIX || "?";
+
+// `${PREFIX}link <topic>` provides a simple shortcut to various useful URLs
 
 const LINKS: { [k: string]: string } = {
   docs: "https://docs.codewars.com/",
@@ -16,7 +18,7 @@ const LINKS: { [k: string]: string } = {
   vim: "https://docs.codewars.com/references/kata-trainer/#editors",
 };
 
-const USAGE: string = `Usage: \`?link {${Object.keys(LINKS).join("|")}}\``;
+const USAGE: string = `Usage: \`${PREFIX}link {${Object.keys(LINKS).join("|")}}\``;
 
 export default async (message: Message, args: CommandArg[]) => {
   // Input validation

--- a/src/events/message/commands/moderation/warn.ts
+++ b/src/events/message/commands/moderation/warn.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 import { fromModerator, getTexts } from "../../../../common";
 import { Message, CommandArg, discordUser, word } from "../types";
-
-const PREFIX = process.env.COMMAND_PREFIX || "?";
+import { PREFIX } from "../../../../common";
 
 const reasons = ["conduct", "content", "spam"];
 const USAGE = `Usage: \`${PREFIX}warn @user {${reasons.join(",")}}\``;

--- a/src/events/message/commands/moderation/warn.ts
+++ b/src/events/message/commands/moderation/warn.ts
@@ -2,8 +2,10 @@ import { z } from "zod";
 import { fromModerator, getTexts } from "../../../../common";
 import { Message, CommandArg, discordUser, word } from "../types";
 
+const PREFIX = process.env.COMMAND_PREFIX || "?";
+
 const reasons = ["conduct", "content", "spam"];
-const USAGE = `Usage: \`?warn @user {${reasons.join(",")}}\``;
+const USAGE = `Usage: \`${PREFIX}warn @user {${reasons.join(",")}}\``;
 const warnTexts: Map<string, string> = getTexts("warn", reasons);
 
 // warn

--- a/src/events/message/index.ts
+++ b/src/events/message/index.ts
@@ -3,7 +3,7 @@ import { Message } from "discord.js";
 import commands, { parseArguments } from "./commands";
 import handlers from "./handlers";
 
-export const PREFIX = process.env.COMMAND_PREFIX || "?";
+const PREFIX = process.env.COMMAND_PREFIX || "?";
 
 const HELP: string = `The following commands are available:
 

--- a/src/events/message/index.ts
+++ b/src/events/message/index.ts
@@ -1,9 +1,7 @@
 import { Message } from "discord.js";
-
 import commands, { parseArguments } from "./commands";
 import handlers from "./handlers";
-
-const PREFIX = process.env.COMMAND_PREFIX || "?";
+import { PREFIX } from "../../common";
 
 const HELP: string = `The following commands are available:
 

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,5 +1,6 @@
 import { Client } from "discord.js";
-import { PREFIX } from "./message";
+
+const PREFIX = process.env.COMMAND_PREFIX || "?";
 
 export const makeOnReady = (bot: Client) => async () => {
   console.log("ready!");

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,6 +1,5 @@
 import { Client } from "discord.js";
-
-const PREFIX = process.env.COMMAND_PREFIX || "?";
+import { PREFIX } from "../common";
 
 export const makeOnReady = (bot: Client) => async () => {
   console.log("ready!");


### PR DESCRIPTION
Closes #30 

We can get rid of all references to `COMMAND_PREFIX` later in one go if required, but at the moment I think it's better to keep the help messages of commands consistent, since currently the "help" command takes `COMMAND_PREFIX` into account but none of the other commands do.