### PR TITLE
Store Config Vars in GitHub Secrets and add client/guild ids

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,3 +13,9 @@ jobs:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: ${{secrets.HEROKU_APP_NAME}}
           heroku_email: ${{secrets.HEROKU_EMAIL}}
+        env:
+          # `HD_` prefix is for this action and is removed when passed to the app.
+          # See https://github.com/AkhileshNS/heroku-deploy#environment-variables
+          HD_BOT_TOKEN: ${{secrets.DISCORD_BOT_TOKEN}}
+          HD_CLIENT_ID: ${{secrets.DISCORD_CLIENT_ID}}
+          HD_GUILD_ID: ${{secrets.DISCORD_GUILD_ID}}


### PR DESCRIPTION
The client and guild ids are necessary for the slash commands.