### PR TITLE
Support configuration with dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .env.development and fill in the values.
+# .env.development is gitignored.
+
+# https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token
+BOT_TOKEN=<bot-token>
+
+# For slash commands
+# CLIENT_ID=
+# GUILD_ID=

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,8 @@
+# DO NOT ADD SECRETS HERE
+# For production, secrets are injected by Heroku Config Vars.
+# BOT_TOKEN
+# CLIENT_ID
+# GUILD_ID
+
+# Add any other configs.
+# CLIENT_ID and GUILD_ID can probably be moved here.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
         env:
           # `HD_` prefix is for this action and is removed when passed to the app.
           # See https://github.com/AkhileshNS/heroku-deploy#environment-variables
+          HD_NODE_ENV: "production"
           HD_BOT_TOKEN: ${{secrets.DISCORD_BOT_TOKEN}}
           HD_CLIENT_ID: ${{secrets.DISCORD_CLIENT_ID}}
           HD_GUILD_ID: ${{secrets.DISCORD_GUILD_ID}}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ npm-debug.log*
 .npm
 node_modules/
 lib/
+
+.env.development

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The following environment variables are used:
 - `BOT_TOKEN` (required): The token used to log in.
 - `COMMAND_PREFIX`: The prefix used to identify commands. Defaults to `?`.
 
+Use `.env.development` (gitignored) to configure these variables.
+
 ## Developement Setup
 
 > NOTE: Please discuss with us first before adding new features to avoid wasting your time.
@@ -33,7 +35,8 @@ After forking this repo and cloning your fork to your local development environm
 1. Change directory to the root of this repo: `$ cd /path/to/your/discord-bot`
 1. Install dependencies and compile TypeScript: `$ npm install`
 1. Start TypeScript compiler process to recompile on change: `$ npm run build:watch`
-1. In a new terminal session, run the bot with [your token](https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token): `$ BOT_TOKEN=... npm start`
+1. Copy `.env.example` to `.env.development` and set `BOT_TOKEN` to [your token](https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token).
+1. In a new terminal session, run the bot with: `$ npm start`
 
 After confirming that the bot works as expected, make changes to the local copy of your fork as appropriate and test your changes by restarting the bot.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "@types/node-fetch": "^2.5.12",
         "common-tags": "^1.8.0",
         "discord.js": "^12.5.3",
+        "dotenv": "^16.0.0",
         "node-fetch": "^2.6.6",
         "tslib": "^2.2.0",
+        "znv": "^0.3.1",
         "zod": "^3.2.0"
       },
       "devDependencies": {
@@ -2568,6 +2570,14 @@
       "dev": true,
       "dependencies": {
         "no-case": "^2.2.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -8044,9 +8054,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -8505,10 +8515,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/znv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/znv/-/znv-0.3.1.tgz",
+      "integrity": "sha512-HqdIrbrHUd4OxZV7OE8t1owjz04TqAQ8EhzN77k5ptzxEWskQzlGIwF/BSkKyFIrYaTDpwF5PAQdkaCIIKYrMA==",
+      "dependencies": {
+        "colorette": "^2.0.16"
+      },
+      "peerDependencies": {
+        "zod": "^3.11.6"
+      }
+    },
+    "node_modules/znv/node_modules/colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+    },
     "node_modules/zod": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.2.0.tgz",
-      "integrity": "sha512-yvcO3FZ8URR+LliMGqaW7tlVOOTzmup3vzKEe9Ds7twyJtdhvYa7dIYr0FbD1wVfWC1OuS83vZfHtCKslPuRhA==",
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
+      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10572,6 +10598,11 @@
       "requires": {
         "no-case": "^2.2.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
     },
     "electron-to-chromium": {
       "version": "1.3.752",
@@ -14866,9 +14897,9 @@
       }
     },
     "tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tweetnacl": {
       "version": "1.0.3",
@@ -15218,10 +15249,25 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
+    "znv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/znv/-/znv-0.3.1.tgz",
+      "integrity": "sha512-HqdIrbrHUd4OxZV7OE8t1owjz04TqAQ8EhzN77k5ptzxEWskQzlGIwF/BSkKyFIrYaTDpwF5PAQdkaCIIKYrMA==",
+      "requires": {
+        "colorette": "^2.0.16"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+        }
+      }
+    },
     "zod": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.2.0.tgz",
-      "integrity": "sha512-yvcO3FZ8URR+LliMGqaW7tlVOOTzmup3vzKEe9Ds7twyJtdhvYa7dIYr0FbD1wVfWC1OuS83vZfHtCKslPuRhA=="
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
+      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "kazk",
   "license": "MIT",
   "engines": {
-    "node": ">= 12"
+    "node": ">= 12",
+    "npm": ">= 7"
   },
   "main": "./lib/main.js",
   "scripts": {
@@ -38,8 +39,10 @@
     "@types/node-fetch": "^2.5.12",
     "common-tags": "^1.8.0",
     "discord.js": "^12.5.3",
+    "dotenv": "^16.0.0",
     "node-fetch": "^2.6.6",
     "tslib": "^2.2.0",
+    "znv": "^0.3.1",
     "zod": "^3.2.0"
   },
   "jest": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,33 @@
+import { resolve } from "path";
+
+import dotenv from "dotenv";
+import { z } from "zod";
+import { parseEnv } from "znv";
+
+// Load config from environment variables.
+// Exits if required configs are missing or invalid.
+export const fromEnv = () => {
+  // Use `.env.development` by default.
+  dotenv.config({
+    path: resolve(process.cwd(), `.env.${process.env.NODE_ENV || "development"}`),
+  });
+  try {
+    return parseEnv(process.env, {
+      BOT_TOKEN: {
+        description:
+          "Your bot token. See https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token",
+        schema: z.string().nonempty(),
+      },
+      // Required for slash commands
+      // CLIENT_ID: { schema: z.string().nonempty() },
+      // GUILD_ID: { schema: z.string().nonempty() },
+    });
+  } catch (e) {
+    if (e instanceof Error) {
+      console.log(e.message);
+    } else {
+      console.error(e);
+    }
+    process.exit(1);
+  }
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,13 @@
 import { Client } from "discord.js";
 
+import { fromEnv } from "./config";
 import { onMessage, makeOnReady } from "./events";
 
-const TOKEN = process.env.BOT_TOKEN;
-if (!TOKEN) throw new Error("missing BOT_TOKEN");
+const config = fromEnv();
 
 const bot = new Client();
 
 bot.once("ready", makeOnReady(bot));
 bot.on("message", onMessage);
 
-bot.login(TOKEN);
+bot.login(config.BOT_TOKEN);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "importHelpers": true,


### PR DESCRIPTION
Use `.env.development` to configure the bot while development. This file is gitignored, so you can store your token there. It's much easier to work with than manually setting the variables. [znv](https://www.npmjs.com/package/znv) is used to make the config type safe and declarative. It also outputs helpful errors.

If a required environment variable is missing, the bot exits with an error like this:

![image](https://user-images.githubusercontent.com/639336/152618112-7514c89a-2517-443d-962c-aeddacd99a1b.png)

If invalid:

![image](https://user-images.githubusercontent.com/639336/152618262-ca61ceff-8be2-4f9b-949f-be54a457b3de.png)

Note that variables in `.env.development` doesn't replace existing environment variables, so you can still set manually if you need to override something temporarily.