### PR TITLE
Allow permissions to be specified in slash commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ BOT_TOKEN=<bot-token>
 # Required to register slash commands
 CLIENT_ID=<client-id>
 GUILD_ID=<guild-id>
+# Recommended, since some slash commands may not be available if not set
+ROLE_EVERYONE=<role-everyone-id>

--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ Feedback is appreciated (Discord or GitHub issues/discussions).
 
 ## Configuration
 
-The following environment variables are required:
+The following environment variables are required for the bot to run:
 
 - `BOT_TOKEN`: The token used to log in.
 - `CLIENT_ID`: The ID of the application associated with the bot.
 - `GUILD_ID`: The ID of the server where slash commands should be registered.
+
+The following environment variables are recommended, since some slash commands may not be available without them:
+
+- `ROLE_EVERYONE`: The ID of the `@everyone` role in the guild where the bot is registered.
 
 Use `.env.development` (gitignored) to configure these variables.
 
@@ -67,6 +71,7 @@ In order to mimic the Codewars Discord server in your development server, you ma
 1. In `.env.development`:
    - Set `BOT_TOKEN` to your [bot token](https://discordjs.guide/preparations/setting-up-a-bot-application.html#your-token)
    - Set `CLIENT_ID` and `GUILD_ID` to your [application ID and server ID](https://support-dev.discord.com/hc/en-us/articles/360028717192-Where-can-I-find-my-Application-Team-Server-ID-), respectively
+   - (Recommended) Set `ROLE_EVERYONE` to the [ID of the `@everyone` role in the guild where the bot is registered](https://anidiots.guide/understanding/roles/)
 1. Start the bot:
 
    ```bash

--- a/src/commands/echo.ts
+++ b/src/commands/echo.ts
@@ -1,4 +1,4 @@
-import { CommandInteraction } from "discord.js";
+import { CommandInteraction, ApplicationCommandPermissionData } from "discord.js";
 import {
   SlashCommandBuilder,
   blockQuote,
@@ -11,6 +11,9 @@ import {
   strikethrough,
   underscore,
 } from "@discordjs/builders";
+import { fromEnv } from "../config";
+
+const config = fromEnv();
 
 const formats: { [k: string]: (s: string) => string } = {
   blockQuote,
@@ -27,6 +30,7 @@ const formats: { [k: string]: (s: string) => string } = {
 export const data = new SlashCommandBuilder()
   .setName("echo")
   .setDescription("Replies with your input, optionally formatted")
+  .setDefaultPermission(false)
   .addStringOption((option) =>
     option.setName("input").setDescription("The input to echo back").setRequired(true)
   )
@@ -37,6 +41,16 @@ export const data = new SlashCommandBuilder()
       .addChoices(Object.keys(formats).map((k) => [k, k]))
   )
   .toJSON();
+
+let permissions: ApplicationCommandPermissionData[] = [];
+if (config.ROLE_EVERYONE) {
+  permissions.push({
+    id: config.ROLE_EVERYONE,
+    type: "ROLE",
+    permission: true,
+  });
+}
+export { permissions };
 
 export const call = async (interaction: CommandInteraction) => {
   const input = interaction.options.getString("input", true);

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,10 +1,14 @@
 // A subcommand example
-import { CommandInteraction } from "discord.js";
+import { CommandInteraction, ApplicationCommandPermissionData } from "discord.js";
 import { SlashCommandBuilder } from "@discordjs/builders";
+import { fromEnv } from "../config";
+
+const config = fromEnv();
 
 export const data = new SlashCommandBuilder()
   .setName("info")
   .setDescription("Replies with info")
+  .setDefaultPermission(false)
   .addSubcommand((sub) =>
     sub
       .setName("user")
@@ -13,6 +17,16 @@ export const data = new SlashCommandBuilder()
   )
   .addSubcommand((sub) => sub.setName("server").setDescription("Info about the server"))
   .toJSON();
+
+let permissions: ApplicationCommandPermissionData[] = [];
+if (config.ROLE_EVERYONE) {
+  permissions.push({
+    id: config.ROLE_EVERYONE,
+    type: "ROLE",
+    permission: true,
+  });
+}
+export { permissions };
 
 export const call = async (interaction: CommandInteraction) => {
   switch (interaction.options.getSubcommand()) {

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,5 +1,8 @@
-import { CommandInteraction } from "discord.js";
+import { CommandInteraction, ApplicationCommandPermissionData } from "discord.js";
 import { SlashCommandBuilder, hyperlink, hideLinkEmbed, userMention } from "@discordjs/builders";
+import { fromEnv } from "../config";
+
+const config = fromEnv();
 
 const LINKS: { [k: string]: { description: string; url: string } } = {
   docs: {
@@ -44,6 +47,7 @@ const LINKS: { [k: string]: { description: string; url: string } } = {
 export const data = new SlashCommandBuilder()
   .setName("link")
   .setDescription("Link to a given topic")
+  .setDefaultPermission(false)
   .addStringOption((option) =>
     option
       .setName("topic")
@@ -55,6 +59,16 @@ export const data = new SlashCommandBuilder()
     option.setName("target").setDescription("Direct the specified user to the given link")
   )
   .toJSON();
+
+let permissions: ApplicationCommandPermissionData[] = [];
+if (config.ROLE_EVERYONE) {
+  permissions.push({
+    id: config.ROLE_EVERYONE,
+    type: "ROLE",
+    permission: true,
+  });
+}
+export { permissions };
 
 export const call = async (interaction: CommandInteraction) => {
   const topic = interaction.options.getString("topic", true);

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,12 @@ export const fromEnv = () => {
           "The server id. See https://support-dev.discord.com/hc/en-us/articles/360028717192-Where-can-I-find-my-Application-Team-Server-ID-",
         schema: z.string().nonempty(),
       },
+      // Recommended, since some slash commands may not be available if not set
+      ROLE_EVERYONE: {
+        description:
+          "The ID for the @everyone role. See https://anidiots.guide/understanding/roles/",
+        schema: z.string().nullable(),
+      },
     });
   } catch (e) {
     if (e instanceof Error) {

--- a/templates/command.ts.hbs
+++ b/templates/command.ts.hbs
@@ -1,11 +1,25 @@
-import { CommandInteraction } from "discord.js";
+import { CommandInteraction, ApplicationCommandPermissionData } from "discord.js";
 import { SlashCommandBuilder } from "@discordjs/builders";
+import { fromEnv } from "../config";
+
+const config = fromEnv();
 
 // {{name}}
 export const data = new SlashCommandBuilder()
   .setName("{{name}}")
   .setDescription("Description for command {{name}}")
+  .setDefaultPermission(false)
   .toJSON();
+
+let permissions: ApplicationCommandPermissionData[] = [];
+if (config.ROLE_EVERYONE) {
+  permissions.push({
+    id: config.ROLE_EVERYONE,
+    type: 'ROLE',
+    permission: true
+  });
+}
+export { permissions };
 
 export const call = async (interaction: CommandInteraction) => {
   // TODO don't forget to include this module in `commands` in `src/commands/index.ts`


### PR DESCRIPTION
This changeset lays the foundations for adding privileged slash commands such as `/introduce` and `/warn`, by allowing command permissions to be specified individually.

A new environment variable `ROLE_EVERYONE` is introduced for specifying the ID of the `@everyone` role in the associated guild, which is optional, though most (all) slash commands will not be available to anyone if not set.

Related: #43 