### PR TITLE
Get command definition asynchronously

### DIFF
--- a/src/commands/echo.ts
+++ b/src/commands/echo.ts
@@ -24,19 +24,20 @@ const formats: { [k: string]: (s: string) => string } = {
   underscore,
 };
 
-export const data = new SlashCommandBuilder()
-  .setName("echo")
-  .setDescription("Replies with your input, optionally formatted")
-  .addStringOption((option) =>
-    option.setName("input").setDescription("The input to echo back").setRequired(true)
-  )
-  .addStringOption((option) =>
-    option
-      .setName("format")
-      .setDescription("The format to use")
-      .addChoices(Object.keys(formats).map((k) => [k, k]))
-  )
-  .toJSON();
+export const data = async () =>
+  new SlashCommandBuilder()
+    .setName("echo")
+    .setDescription("Replies with your input, optionally formatted")
+    .addStringOption((option) =>
+      option.setName("input").setDescription("The input to echo back").setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("format")
+        .setDescription("The format to use")
+        .addChoices(Object.keys(formats).map((k) => [k, k]))
+    )
+    .toJSON();
 
 export const call = async (interaction: CommandInteraction) => {
   const input = interaction.options.getString("input", true);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -23,7 +23,7 @@ import * as rankup from "./rankup";
 
 export type Command = {
   // Data to send when registering.
-  data: RESTPostAPIApplicationCommandsJSONBody;
+  data: () => Promise<RESTPostAPIApplicationCommandsJSONBody>;
   // Handler.
   call: (interaction: CommandInteraction) => Promise<void>;
   // Roles authorized to use this command.
@@ -46,7 +46,7 @@ export const updateCommands = async (client: Client, config: Config) => {
   if (!guild) throw new Error("Failed to get the current guild");
 
   const rest = new REST({ version: "9" }).setToken(config.BOT_TOKEN);
-  const body = Object.values(commands).map((c) => c.data);
+  const body = await Promise.all(Object.values(commands).map((c) => c.data()));
   // Global commands are cached for one hour.
   // Guild commands update instantly.
   // discord.js recommends guild command when developing and global in production.

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -2,17 +2,18 @@
 import { CommandInteraction } from "discord.js";
 import { SlashCommandBuilder } from "@discordjs/builders";
 
-export const data = new SlashCommandBuilder()
-  .setName("info")
-  .setDescription("Replies with info")
-  .addSubcommand((sub) =>
-    sub
-      .setName("user")
-      .setDescription("Info about a user")
-      .addUserOption((o) => o.setName("user").setDescription("The user"))
-  )
-  .addSubcommand((sub) => sub.setName("server").setDescription("Info about the server"))
-  .toJSON();
+export const data = async () =>
+  new SlashCommandBuilder()
+    .setName("info")
+    .setDescription("Replies with info")
+    .addSubcommand((sub) =>
+      sub
+        .setName("user")
+        .setDescription("Info about a user")
+        .addUserOption((o) => o.setName("user").setDescription("The user"))
+    )
+    .addSubcommand((sub) => sub.setName("server").setDescription("Info about the server"))
+    .toJSON();
 
 export const call = async (interaction: CommandInteraction) => {
   switch (interaction.options.getSubcommand()) {

--- a/src/commands/introduce.ts
+++ b/src/commands/introduce.ts
@@ -6,23 +6,24 @@ const channels = ["help-solve"];
 const channelTexts: Map<string, string> = getTexts("introduce", channels);
 
 // introduce
-export const data = new SlashCommandBuilder()
-  .setName("introduce")
-  .setDescription("Introduce the user to the specified channel")
-  .setDefaultPermission(false)
-  .addUserOption((option) =>
-    option
-      .setName("user")
-      .setDescription("User to introduce the specified channel to")
-      .setRequired(true)
-  )
-  .addChannelOption((option) =>
-    option
-      .setName("channel")
-      .setDescription("Channel to introduce the specified user to")
-      .setRequired(true)
-  )
-  .toJSON();
+export const data = async () =>
+  new SlashCommandBuilder()
+    .setName("introduce")
+    .setDescription("Introduce the user to the specified channel")
+    .setDefaultPermission(false)
+    .addUserOption((option) =>
+      option
+        .setName("user")
+        .setDescription("User to introduce the specified channel to")
+        .setRequired(true)
+    )
+    .addChannelOption((option) =>
+      option
+        .setName("channel")
+        .setDescription("Channel to introduce the specified user to")
+        .setRequired(true)
+    )
+    .toJSON();
 
 export const authorizedRoles = ["admin", "mods", "power-users"];
 

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -41,20 +41,21 @@ const LINKS: { [k: string]: { description: string; url: string } } = {
 };
 
 // link
-export const data = new SlashCommandBuilder()
-  .setName("link")
-  .setDescription("Link to a given topic")
-  .addStringOption((option) =>
-    option
-      .setName("topic")
-      .setDescription("The topic to link to")
-      .setRequired(true)
-      .addChoices(Object.keys(LINKS).map((k) => [LINKS[k].description, k]))
-  )
-  .addUserOption((option) =>
-    option.setName("target").setDescription("Direct the specified user to the given link")
-  )
-  .toJSON();
+export const data = async () =>
+  new SlashCommandBuilder()
+    .setName("link")
+    .setDescription("Link to a given topic")
+    .addStringOption((option) =>
+      option
+        .setName("topic")
+        .setDescription("The topic to link to")
+        .setRequired(true)
+        .addChoices(Object.keys(LINKS).map((k) => [LINKS[k].description, k]))
+    )
+    .addUserOption((option) =>
+      option.setName("target").setDescription("Direct the specified user to the given link")
+    )
+    .toJSON();
 
 export const call = async (interaction: CommandInteraction) => {
   const topic = interaction.options.getString("topic", true);

--- a/src/commands/rankup.ts
+++ b/src/commands/rankup.ts
@@ -136,38 +136,39 @@ async function getNextRank(
 }
 
 // rankup
-export const data = new SlashCommandBuilder()
-  .setName("rankup")
-  .setDescription("Find out how many Kata to complete to advance to the next rank, and more")
-  .addStringOption((option) =>
-    option
-      .setName("username")
-      .setDescription("The Codewars username to query rankup statistics for")
-  )
-  .addStringOption((option) =>
-    option.setName("target").setDescription("The target user or rank to reach")
-  )
-  .addStringOption((option) =>
-    option
-      .setName("language")
-      .setDescription("The programming language ID to query rankup statistics for")
-  )
-  .addStringOption((option) =>
-    option
-      .setName("mode")
-      .setDescription("Choose your preferred method to reach your target")
-      .addChoices(modes.map((mode) => [mode.description, mode.name]))
-  )
-  .addStringOption((option) =>
-    option
-      .setName("limit")
-      .setDescription("Don't suggest Kata above this rank")
-      .addChoices(limits.map((limit) => [limit, limit]))
-  )
-  .addBooleanOption((option) =>
-    option.setName("ephemeral").setDescription("Don't show rank up statistics to others")
-  )
-  .toJSON();
+export const data = async () =>
+  new SlashCommandBuilder()
+    .setName("rankup")
+    .setDescription("Find out how many Kata to complete to advance to the next rank, and more")
+    .addStringOption((option) =>
+      option
+        .setName("username")
+        .setDescription("The Codewars username to query rankup statistics for")
+    )
+    .addStringOption((option) =>
+      option.setName("target").setDescription("The target user or rank to reach")
+    )
+    .addStringOption((option) =>
+      option
+        .setName("language")
+        .setDescription("The programming language ID to query rankup statistics for")
+    )
+    .addStringOption((option) =>
+      option
+        .setName("mode")
+        .setDescription("Choose your preferred method to reach your target")
+        .addChoices(modes.map((mode) => [mode.description, mode.name]))
+    )
+    .addStringOption((option) =>
+      option
+        .setName("limit")
+        .setDescription("Don't suggest Kata above this rank")
+        .addChoices(limits.map((limit) => [limit, limit]))
+    )
+    .addBooleanOption((option) =>
+      option.setName("ephemeral").setDescription("Don't show rank up statistics to others")
+    )
+    .toJSON();
 
 export const call = async (interaction: CommandInteraction) => {
   let username = interaction.options.getString("username");

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -24,21 +24,22 @@ const warnTexts: Map<string, string> = getTexts(
 );
 
 // warn
-export const data = new SlashCommandBuilder()
-  .setName("warn")
-  .setDescription("Warn the user for violation of server rules")
-  .setDefaultPermission(false)
-  .addUserOption((option) =>
-    option.setName("user").setDescription("The user who violated server rules").setRequired(true)
-  )
-  .addStringOption((option) =>
-    option
-      .setName("reason")
-      .setDescription("The reason the specified user violated server rules")
-      .setRequired(true)
-      .addChoices(reasons.map((reason) => [reason.description, reason.name]))
-  )
-  .toJSON();
+export const data = async () =>
+  new SlashCommandBuilder()
+    .setName("warn")
+    .setDescription("Warn the user for violation of server rules")
+    .setDefaultPermission(false)
+    .addUserOption((option) =>
+      option.setName("user").setDescription("The user who violated server rules").setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("reason")
+        .setDescription("The reason the specified user violated server rules")
+        .setRequired(true)
+        .addChoices(reasons.map((reason) => [reason.description, reason.name]))
+    )
+    .toJSON();
 
 export const authorizedRoles = ["admin", "mods"];
 

--- a/templates/command.ts.hbs
+++ b/templates/command.ts.hbs
@@ -2,10 +2,11 @@ import { CommandInteraction } from "discord.js";
 import { SlashCommandBuilder } from "@discordjs/builders";
 
 // {{name}}
-export const data = new SlashCommandBuilder()
-  .setName("{{name}}")
-  .setDescription("Description for command {{name}}")
-  .toJSON();
+export const data = async () =>
+  new SlashCommandBuilder()
+    .setName("{{name}}")
+    .setDescription("Description for command {{name}}")
+    .toJSON();
 
 export const call = async (interaction: CommandInteraction) => {
   // TODO don't forget to include this module in `commands` in `src/commands/index.ts`


### PR DESCRIPTION
Probably the simplest and the most consistent way to allow fetching data when defining commands.

Necessary to define `/rankup` with languages data.