### PR TITLE
Accept language name

### DIFF
--- a/src/codewars.ts
+++ b/src/codewars.ts
@@ -48,7 +48,17 @@ export class UserNotFoundError extends Error {
   }
 }
 
+let languages: Language[] | null = null;
+/**
+ * Get the list of supported languages using Codewars API.
+ * The result is stored, so this only requests once.
+ * The bot restarts at least once a day, so this should be fine for now.
+ * @returns Supported languages
+ */
 export const getLanguages: () => Promise<Language[]> = async () => {
-  const response = await fetch("https://www.codewars.com/api/v1/languages");
-  return z.object({ data: z.array(Language) }).parse(await response.json()).data;
+  if (!languages) {
+    const response = await fetch("https://www.codewars.com/api/v1/languages");
+    languages = z.object({ data: z.array(Language) }).parse(await response.json()).data;
+  }
+  return languages;
 };


### PR DESCRIPTION
Discord started sending the `name` of autocompleted options. Work around by finding the language id by name.