### PR TITLE
Remove `commands.permissions.set`

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,14 +1,7 @@
-import {
-  RESTPostAPIApplicationCommandsJSONBody,
-  RESTPutAPIApplicationGuildCommandsResult,
-  Routes,
-} from "discord-api-types/v9";
+import { RESTPostAPIApplicationCommandsJSONBody, Routes } from "discord-api-types/v9";
 import {
   Client,
   CommandInteraction,
-  Guild,
-  GuildApplicationCommandPermissionData,
-  ApplicationCommandPermissionData,
   AutocompleteInteraction,
   ApplicationCommandOptionChoice,
 } from "discord.js";
@@ -33,9 +26,6 @@ export type Command = {
   autocomplete?: (
     interaction: AutocompleteInteraction
   ) => Promise<ApplicationCommandOptionChoice[]>;
-  // Roles authorized to use this command.
-  // Ignored unless `data.default_permission` is `false`.
-  authorizedRoles?: string[];
 };
 
 export const commands: { [k: string]: Command } = {
@@ -59,48 +49,7 @@ export const updateCommands = async (client: Client, config: Config) => {
   // Guild commands update instantly.
   // discord.js recommends guild command when developing and global in production.
   // For now, always use guild commands because our bot is only added to our server.
-  const result = await rest.put(
-    Routes.applicationGuildCommands(config.CLIENT_ID, config.GUILD_ID),
-    {
-      body,
-    }
-  );
-  await setPermissions(guild, result as RESTPutAPIApplicationGuildCommandsResult);
-};
-
-// Enable restricted commands for the allowed roles.
-// Warn if none of the allowed roles are found.
-const setPermissions = async (guild: Guild, result: RESTPutAPIApplicationGuildCommandsResult) => {
-  const fullPermissions: GuildApplicationCommandPermissionData[] = [];
-  for (const cmd of result) {
-    if (cmd.default_permission !== false) continue;
-
-    const { authorizedRoles } = commands[cmd.name];
-    if (!Array.isArray(authorizedRoles)) {
-      throw new Error(`/${cmd.name} is restricted without authorizedRoles`);
-    }
-
-    const permissions: ApplicationCommandPermissionData[] = [];
-    for (const name of authorizedRoles) {
-      const role = guild.roles.cache.find((role) => role.name === name);
-      if (role) {
-        permissions.push({ id: role.id, type: "ROLE", permission: true });
-      }
-    }
-
-    if (permissions.length > 0) {
-      fullPermissions.push({ id: cmd.id, permissions });
-    } else {
-      console.warn(
-        `/${cmd.name} is unusable because none of the authorized roles exist.`,
-        JSON.stringify(authorizedRoles)
-      );
-    }
-  }
-
-  if (fullPermissions.length > 0) {
-    console.log("Setting permissions for restricted (/) commands");
-    await guild.commands.permissions.set({ fullPermissions });
-    console.log("Successfully set permissions for restricted (/) commands");
-  }
+  await rest.put(Routes.applicationGuildCommands(config.CLIENT_ID, config.GUILD_ID), {
+    body,
+  });
 };

--- a/src/commands/introduce.ts
+++ b/src/commands/introduce.ts
@@ -25,8 +25,6 @@ export const data = async () =>
     )
     .toJSON();
 
-export const authorizedRoles = ["admin", "mods", "power-users"];
-
 export const call = async (interaction: CommandInteraction) => {
   const user = interaction.options.getUser("user", true);
   const channel = interaction.options.getChannel("channel", true);

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -41,8 +41,6 @@ export const data = async () =>
     )
     .toJSON();
 
-export const authorizedRoles = ["admin", "mods"];
-
 export const call = async (interaction: CommandInteraction) => {
   const user = interaction.options.getUser("user", true);
   const reason = interaction.options.getString("reason", true);


### PR DESCRIPTION
Enable them in `Command Permissions` page instead.

We can also restrict by channel there as well, but just fixing 405 error for now that's preventing the bot to start.