### PR TITLE
Add /leaderboard user subcommand

### DIFF
--- a/src/codewars.ts
+++ b/src/codewars.ts
@@ -124,3 +124,22 @@ export async function getLeaderboard(
   let start = (startPosition - 1) % USERS_PER_PAGE;
   return result.slice(start, start + limit);
 }
+/**
+ * Get a leaderboard for rank score searching for a given user.
+ *
+ * @param lang - Optional language to get the leaderboard.
+ *               Overall leaderboard is returned if unspecified.
+ * @param user - The name of the Codewars user to search for.
+ * @returns Language or overall leaderboard
+ */
+export async function getLeaderboardForUser(
+  lang: string | null,
+  user: string
+): Promise<LeaderboardPosition[]> {
+  lang = lang ?? "overall";
+  const url = "https://www.codewars.com/api/v1/leaders/ranks/" + lang + "?user=" + user;
+  const response = await fetch(url);
+  if (response.status === 404) throw new UserNotFoundError(user);
+  return z.object({ data: z.array(LeaderboardPosition) }).parse(await response.json()).data;
+}
+

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -1,19 +1,31 @@
 import { CommandInteraction } from "discord.js";
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { RequestError, getLeaderboard, Language, LeaderboardPosition } from "../codewars";
+import {
+  RequestError,
+  getLeaderboard,
+  Language,
+  LeaderboardPosition,
+  getLeaderboardForUser,
+} from "../codewars";
 import { table, TableUserConfig } from "table";
-import { findLanguage, checkBotPlayground } from "../common";
+import { findLanguage, checkBotPlayground, getUsername } from "../common";
 export { languageAutocomplete as autocomplete } from "../common";
 
-const tableConfig: TableUserConfig = {
-  drawHorizontalLine: (lineIndex: number, rowCount: number) =>
-    lineIndex < 2 || lineIndex === rowCount,
-  columns: [
-    { alignment: "right" },
-    { alignment: "left" },
-    { alignment: "right" },
-    { alignment: "left" },
-  ],
+const tableConfig = (highlight: number | null): TableUserConfig => {
+  let drawHorizontalLine =
+    highlight === null
+      ? (lineIndex: number, rowCount: number) => lineIndex < 2 || lineIndex === rowCount
+      : (lineIndex: number, rowCount: number) =>
+          [0, 1, highlight + 1, highlight + 2, rowCount].includes(lineIndex);
+  return {
+    drawHorizontalLine,
+    columns: [
+      { alignment: "right" },
+      { alignment: "left" },
+      { alignment: "right" },
+      { alignment: "left" },
+    ],
+  };
 };
 
 // leaderboard
@@ -21,33 +33,54 @@ export const data = async () =>
   new SlashCommandBuilder()
     .setName("leaderboard")
     .setDescription("Show the language score leaderboards")
-    .addStringOption((option) =>
-      option
-        .setName("language")
-        .setDescription("The programming language to show leaderboard for")
-        .setAutocomplete(true)
+    .addSubcommand((sub) =>
+      sub
+        .setName("top")
+        .setDescription("Show the language score top 500 leaderboards")
+        .addStringOption((option) =>
+          option
+            .setName("language")
+            .setDescription("The programming language to show leaderboard for")
+            .setAutocomplete(true)
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName("startposition")
+            .setDescription("The top shown position (default 1)")
+            .setMinValue(1)
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName("limit")
+            .setDescription("The number of shown users (default 10, range 1 - 25)")
+            .setMinValue(1)
+            // cut off at 25 because of Discord message length limit, 31 would fit
+            .setMaxValue(25)
+        )
+        .addBooleanOption((option) =>
+          option.setName("ephemeral").setDescription("Don't show leaderboard to others")
+        )
     )
-    .addIntegerOption((option) =>
-      option
-        .setName("startposition")
-        .setDescription("The top shown position (default 1)")
-        // limits seem not to be checked by Discord API, maybe support in the future
-        .setMinValue(1)
-    )
-    .addIntegerOption((option) =>
-      option
-        .setName("limit")
-        .setDescription("The number of shown users (default 10, range 1 - 25)")
-        .setMinValue(1)
-        // cut off at 25 because of Discord message length limit, 31 would fit
-        .setMaxValue(25)
-    )
-    .addBooleanOption((option) =>
-      option.setName("ephemeral").setDescription("Don't show leaderboard to others")
+    .addSubcommand((sub) =>
+      sub
+        .setName("user")
+        .setDescription("Search for a user on the language score leaderboard")
+        .addStringOption((option) =>
+          option.setName("username").setDescription("The Codewars username to search for")
+        )
+        .addStringOption((option) =>
+          option
+            .setName("language")
+            .setDescription("The programming language to show leaderboard for")
+            .setAutocomplete(true)
+        )
+        .addBooleanOption((option) =>
+          option.setName("ephemeral").setDescription("Don't show leaderboard to others")
+        )
     )
     .toJSON();
 
-function format(lang: Language | null, leaderboard: LeaderboardPosition[]) {
+function format(lang: Language | null, leaderboard: LeaderboardPosition[], user: string | null) {
   const data = [
     ["#", "username", "score", "rank"],
     ...leaderboard.map((u) => [u.position, u.username, u.score, getRank(u.rank)]),
@@ -55,7 +88,7 @@ function format(lang: Language | null, leaderboard: LeaderboardPosition[]) {
   return (
     `:trophy: **${lang?.name ?? "Overall"} leaderboard** :medal:\n` +
     "```\n" +
-    table(data, tableConfig) +
+    table(data, tableConfig(user ? leaderboard.findIndex((u) => user === u.username) : null)) +
     "\n```"
   );
 }
@@ -65,18 +98,36 @@ function getRank(rank: number) {
 }
 
 export const call = async (interaction: CommandInteraction) => {
-  const language = await findLanguage(interaction.options.getString("language"));
-  const startPosition = Math.max(interaction.options.getInteger("startposition") ?? 1, 1);
-  const limit = Math.min(Math.max(interaction.options.getInteger("limit") ?? 10, 1), 25);
   const ephemeral = interaction.options.getBoolean("ephemeral") || false;
   checkBotPlayground(ephemeral, interaction);
+  const language = await findLanguage(interaction.options.getString("language"));
+  let leaderboard: LeaderboardPosition[] = [];
+  let user = null;
+  switch (interaction.options.getSubcommand()) {
+    case "top":
+      const startPosition = Math.max(interaction.options.getInteger("startposition") ?? 1, 1);
+      const limit = Math.min(Math.max(interaction.options.getInteger("limit") ?? 10, 1), 25);
+      leaderboard = await getLeaderboard(language?.id ?? null, startPosition, limit);
+      if (leaderboard.length == 0)
+        throw new RequestError(`No leaderboard entries found for position ${startPosition}.`);
+      break;
 
-  const leaderboard = await getLeaderboard(language?.id ?? null, startPosition, limit);
-  if (leaderboard.length == 0)
-    throw new RequestError(`No leaderboard entries found for position ${startPosition}.`);
+    case "user":
+      user = getUsername(interaction);
+      leaderboard = await getLeaderboardForUser(language?.id ?? null, user);
+      if (leaderboard.length == 0) {
+        await interaction.reply({
+          content: `${user} was not found on the ${
+            language?.name ?? "Overall"
+          } top 500 leaderboard`,
+          ephemeral,
+        });
+        return;
+      }
+  }
 
   await interaction.reply({
-    content: format(language, leaderboard),
+    content: format(language, leaderboard, user),
     ephemeral,
   });
 };

--- a/src/commands/rankup.ts
+++ b/src/commands/rankup.ts
@@ -1,7 +1,7 @@
-import { CommandInteraction, GuildMember } from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { RequestError, getScore, Language } from "../codewars";
-import { checkBotPlayground, findLanguage } from "../common";
+import { getScore, Language } from "../codewars";
+import { checkBotPlayground, findLanguage, getUsername } from "../common";
 export { languageAutocomplete as autocomplete } from "../common";
 
 const LEAST = "least";
@@ -149,13 +149,7 @@ export const data = async () =>
     .toJSON();
 
 export const call = async (interaction: CommandInteraction) => {
-  let username = interaction.options.getString("username");
-  if (!username) {
-    const member = interaction.member;
-    const displayName = member instanceof GuildMember ? member.displayName : member?.nick;
-    if (!displayName) throw new RequestError("Failed to fetch the name of the current user");
-    username = displayName;
-  }
+  const username = getUsername(interaction);
   const target = interaction.options.getString("target");
   const language = await findLanguage(interaction.options.getString("language"));
   const mode = interaction.options.getString("mode") || DEFAULTMODE;

--- a/src/commands/userinfo.ts
+++ b/src/commands/userinfo.ts
@@ -1,7 +1,7 @@
-import { CommandInteraction, GuildMember } from "discord.js";
+import { CommandInteraction } from "discord.js";
 import { SlashCommandBuilder } from "@discordjs/builders";
-import { RequestError, getUser } from "../codewars";
-import { checkBotPlayground } from "../common";
+import { getUser } from "../codewars";
+import { checkBotPlayground, getUsername } from "../common";
 
 async function getUserInfo(name: string): Promise<string> {
   let user = await getUser(name);
@@ -31,14 +31,7 @@ export const data = async () =>
     .toJSON();
 
 export const call = async (interaction: CommandInteraction) => {
-  let username = interaction.options.getString("username");
-  if (!username) {
-    const member = interaction.member;
-    const displayName = member instanceof GuildMember ? member.displayName : member?.nick;
-    if (!displayName) throw new RequestError("Failed to fetch the name of the current user");
-    username = displayName;
-  }
-
+  const username = getUsername(interaction);
   const ephemeral = interaction.options.getBoolean("ephemeral") || false;
   checkBotPlayground(ephemeral, interaction);
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from "fs";
 import * as path from "path";
-import { AutocompleteInteraction, CommandInteraction, TextChannel } from "discord.js";
+import {
+  AutocompleteInteraction,
+  CommandInteraction,
+  CommandInteractionOption,
+  GuildMember,
+  TextChannel,
+} from "discord.js";
 import { RequestError, getLanguages, Language } from "./codewars";
 import fuzzysearch from "fuzzysearch";
 
@@ -17,6 +23,23 @@ export const getTexts = (commandName: string, values: string[]): Map<string, str
     process.exit(1);
   }
   return texts;
+};
+
+/**
+ * Attemps to parse a username from the 'username' option. If no value is present the display name of the user sending the interaction is taken.
+ * @param interaction the CommandInteraction to get the values from
+ * @returns username
+ * @throws RequestError if the username could not be fetched
+ */
+export const getUsername = (interaction: CommandInteraction): string => {
+  let username = interaction.options.getString("username");
+  if (!username) {
+    const member = interaction.member;
+    const displayName = member instanceof GuildMember ? member.displayName : member?.nick;
+    if (!displayName) throw new RequestError("Failed to fetch the name of the current user");
+    username = displayName;
+  }
+  return username;
 };
 
 /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -48,7 +48,7 @@ export const getUsername = (interaction: CommandInteraction): string => {
  * @returns List of fuzzy matching languages, max 25
  */
 export const languageAutocomplete = async (interaction: AutocompleteInteraction) => {
-  const focused = interaction.options.data.find((opt) => opt.focused);
+  const focused = getFocused(interaction.options.data);
   // The following shouldn't happen since "language" is the only option with autocompletion, but
   // this can be used to detect the focused option if we have multiple autocomplete options.
   if (focused?.name !== "language") return [];
@@ -69,6 +69,14 @@ export const languageAutocomplete = async (interaction: AutocompleteInteraction)
   // Make sure the response is 25 items or less.
   return filtered.slice(0, 25);
 };
+
+function getFocused(
+  data: readonly CommandInteractionOption[] | undefined
+): CommandInteractionOption | undefined {
+  return (
+    data?.find((opt) => opt.focused) ?? data?.map((opt) => getFocused(opt.options)).find((o) => o)
+  );
+}
 
 /**
  * Attempts to parse a language matching by id or name to the given language option string or


### PR DESCRIPTION
* extract `getUsername()` to common.ts
* fix `languageAutocomplete()` to work with subcommands
* highlight searched user on leaderboard:
![kazk on Overall leaderboard](https://user-images.githubusercontent.com/28844868/186273271-2c2bce47-21b0-4f2c-a1bc-9c7f2b523afa.png)
