### PR TITLE
restrict /echo to #bot-playground

### DIFF
--- a/src/commands/echo.ts
+++ b/src/commands/echo.ts
@@ -11,6 +11,7 @@ import {
   strikethrough,
   underscore,
 } from "discord.js";
+import { checkBotPlayground } from "../common";
 
 const formats: { [k: string]: (s: string) => string } = {
   blockQuote,
@@ -40,6 +41,7 @@ export const data = async () =>
     .toJSON();
 
 export const call = async (interaction: ChatInputCommandInteraction) => {
+  checkBotPlayground(false, interaction);
   const input = interaction.options.getString("input", true);
   const format = interaction.options.getString("format");
   const msg = format && formats.hasOwnProperty(format) ? formats[format](input) : input;


### PR DESCRIPTION
Since the `/echo` command is only implemented for testing purposes we should restrict its usage to the #bot-playground channel to prevent users from impersonating the bot or sending seemingly "official" messages.